### PR TITLE
fix(exec-env): detect and use asdf-managed Java to define JAVA_HOME

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# if asdf provides java, then let's use that rather the system one (if at all avail)
+if asdf current java > /dev/null 2>&1
+then
+    export JAVA_HOME=$(asdf where java)
+fi


### PR DESCRIPTION
Hi,

In case of java is also managed by asdf, spring cli failed to found java.

This is the same case for asdf-maven plugin :
https://github.com/halcyon/asdf-maven/blob/master/bin/exec-env
If asdf manage java, we use it to define JAVA_HOME env var and spring cli can work.

Thank you.