### PR TITLE
fix: download URL

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -37,7 +37,7 @@ installer() {
 
 download_url() {
   local version=$1
-  echo "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/${version}/spring-boot-cli-${version}-bin.tar.gz"
+  echo "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-cli/${version}/spring-boot-cli-${version}-bin.tar.gz"
 }
 
 fail() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly releases_path="https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/"
+readonly releases_path="https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-cli/"
 cmd="curl -Ls $releases_path"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942


### PR DESCRIPTION
Official download URL changed for the cli tools, now it uses maven central repo, as seen here: https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started.html#getting-started.installing.cli

Tested the changes with rtx:

```bash
rtx plugin uninstall spring-boot
RTX_DISABLE_DEFAULT_SHORTHANDS=1 rtx plugin install spring-boot https://github.com/AlexCzar/asdf-spring-boot.git
```